### PR TITLE
JAX version defined in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "discoeb"
 version = "0.1.0"
 dependencies = [
-    "jax",
+    "jax==0.4.33",
     "diffrax==0.4.1",
     "equinox",
     "jaxtyping",


### PR DESCRIPTION
If you install the dependencies from scratch as described in the `README`, the latest version of `jax` will be installed, which is currently version 0.4.34.

If you then run the minimal example or the unit tests, you will get the following error message:
```
TypeError: Called multiply with a float0 array. float0s do not support any operations by design because they are not compatible with non-trivial vector spaces. No implicit dtype conversion is done. You can use np.zeros_like(arr, dtype=np.float) to cast a float0 array to a regular zeros array.
If you didn't expect to get a float0 you might have accidentally taken a gradient with respect to an integer argument.
```

The reason for the error is that the variables `dgi`/`dgc` in `discoeb.thermodynamics_recfast.SahaBoltzmann_jvp` and `dgj`/`dgi` in `discoeb.thermodynamics_recfast.fBoltzmann_jvp` are of type `float0`. You can solve this problem by explicitly defining the `dtype` of these variables.

However, we then get another error from `diffrax`'s `diffeqsolve` function:
`ValueError: setting an array element with a sequence.`

An instant fix for now is to set the `jax` version to 0.4.33.